### PR TITLE
Feature/parallel devserver compiler

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,6 +1,7 @@
 module.exports = {
   use: [
     "@factorial/frontend-stack-core",
+    "@factorial/frontend-stack-pattern-lab",
     "@factorial/frontend-stack-postcss-export-custom-variables"
   ],
   options: {

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,8 +1,6 @@
 module.exports = {
   use: [
-    // "@factorial/frontend-stack-core",
-    // This must point to the frontend-stack on branch 'feature/dev-server-with-linting'
-    "../factorial-frontend-stack/packages/core",
+    "@factorial/frontend-stack-core",
     "@factorial/frontend-stack-postcss-export-custom-variables"
   ],
   options: {

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,6 +1,8 @@
 module.exports = {
   use: [
-    "@factorial/frontend-stack-core",
+    // "@factorial/frontend-stack-core",
+    // This must point to the frontend-stack on branch 'feature/dev-server-with-linting'
+    "../factorial-frontend-stack/packages/core",
     "@factorial/frontend-stack-postcss-export-custom-variables"
   ],
   options: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "npm-run-all": "^4.1.3"
   },
   "scripts": {
-    "start": "yarn run neutrino start",
+    "start": "run-p dev:*",
+    "dev:neutrino": "yarn run neutrino start",
+    "dev:patternlab": "php core/console --watch",
     "build": "yarn run neutrino build --options.env.NODE_ENV production",
     "lint": "npm-run-all lint:*",
     "lint:css": "yarn run neutrino stylelint",


### PR DESCRIPTION
Adds two new commands to packages.json script section:
**dev:neutrino**: starts neutrino workflow
**dev:patternlab**: starts patternalb watch process

Also changes the **start** command to use npm-run-all in parallel mode to start both new tasks with just one command.